### PR TITLE
Week 1: Additional Assignment: CSS Units explained.

### DIFF
--- a/Week-1/README
+++ b/Week-1/README
@@ -1,0 +1,19 @@
+PIXEL
+-----
+Pixel (px) is a commonly used CSS unit on websites. pxis not scalable, it is an absolute unit. Change in the value of another element does not affect the value of absolute units. The value assigned is fixed irrespective of the user setting.
+
+EM
+---
+EM is based on the font size of the parent element. If a parent element has a different size than the root element, the EM calculation will be based off of the parent element, and not the root element.
+
+REM
+----
+Relative to the root element (HTML tag)
+REM is relative to the root (HTML) font size, so if you wish to scale the element’s size based on the root size, no matter what the parent size is, use REM. If you’ve used EM and are finding sizing issues due to lots of nested elements, REM will probably be the better choice.
+By default, the browser font size is set to 16px.
+
+VH & VW
+-------
+Let’s consider an example of a mobile screen viewport that is 480px x 800px.
+1 VW = 1% of the viewport’s width (or 4.8px)
+1 VH = 1% of the viewport’s height (or 8px)

--- a/Week-1/index.html
+++ b/Week-1/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta charset="UTF-8" />
+    <link rel="stylesheet" href="style.css" />
+    <script type="text/javascript" src="script.js"></script>
+    <title>PIXEL VS EM VS REM</title>
+  </head>
+  <body>
+    <div class="lg-font">
+      <p class="em">Hello World - em</p>
+    </div>
+
+    <div class="lg-font">
+      <p class="rem">Hello World - rem</p>
+    </div>
+
+    <div class="lg-font">
+      <p class="pixel">Hello World - pixel</p>
+    </div>
+  </body>
+</html>

--- a/Week-1/style.css
+++ b/Week-1/style.css
@@ -1,0 +1,19 @@
+html {
+  font-size: 16px;
+}
+
+.lg-font {
+  font-size: 30px;
+}
+
+p.rem {
+  font-size: 1rem;
+}
+
+p.em {
+  font-size: 1em;
+}
+
+p.em {
+  font-size: 1pixel;
+}


### PR DESCRIPTION
PIXEL
-----
Pixel (px) is a commonly used CSS unit on websites. pxis not scalable, it is an absolute unit. Change in the value of another element does not affect the value of absolute units. The value assigned is fixed irrespective of the user setting.

EM
---
EM is based on the font size of the parent element. If a parent element has a different size than the root element, the EM calculation will be based off of the parent element, and not the root element.

REM
----
Relative to the root element (HTML tag)
REM is relative to the root (HTML) font size, so if you wish to scale the element’s size based on the root size, no matter what the parent size is, use REM. If you’ve used EM and are finding sizing issues due to lots of nested elements, REM will probably be the better choice.
By default, the browser font size is set to 16px.

VH & VW
-------
Let’s consider an example of a mobile screen viewport that is 480px x 800px.
1 VW = 1% of the viewport’s width (or 4.8px)
1 VH = 1% of the viewport’s height (or 8px)